### PR TITLE
build: update dependencies to their latest versions

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,24 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-05-20T21:12:36.092525200Z">
+        <DropdownSelection timestamp="2025-05-19T23:44:22.321999600Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=MBW8PRDASSXWEEQC" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
-      <SelectionState runConfigName="TeamDaoTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="LeagueDaoTest">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-08-15T13:00:16.855827100Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Ahmed90\.android\avd\Pixel_8_Pro_API_28.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Ahmed\.android\avd\Pixel_Tablet.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,24 +2,26 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
-    id 'dagger.hilt.android.plugin'
     id 'androidx.navigation.safeargs'
     //Google services Gradle plugin
     id 'com.google.gms.google-services'
     id 'kotlin-android'
     id "com.guardsquare.appsweep" version "latest.release"
     id 'kotlin-parcelize'
+
+    id 'com.google.devtools.ksp'
+    id 'com.google.dagger.hilt.android'
 }
 
 android {
     namespace 'com.dev.goalpulse'
-    compileSdk 34
+    compileSdk 35
     defaultConfig {
         applicationId "com.dev.goalpulse"
         minSdk 27
         targetSdk 34
-        versionCode 5
-        versionName "1.0"
+        versionCode 6
+        versionName "1.0.1"
 
         testInstrumentationRunner "com.dev.goalpulse.HiltTestRunner"
 
@@ -52,22 +54,22 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.gridlayout:gridlayout:1.0.0'
+    implementation 'androidx.gridlayout:gridlayout:1.1.0'
 
     // Google Play services library
-    implementation 'com.google.android.gms:play-services-base:18.2.0'
-    implementation("com.google.android.gms:play-services-auth:20.6.0")
+    implementation 'com.google.android.gms:play-services-base:18.7.0'
+    implementation("com.google.android.gms:play-services-auth:21.3.0")
     implementation 'androidx.preference:preference-ktx:1.2.1'
-    def nav_version = "2.5.3"
-    def room_version = "2.5.1"
+    def nav_version = "2.9.0"
+    def room_version = "2.7.1"
 
-    implementation 'androidx.core:core-ktx:1.10.1'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.9.0-alpha01'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.core:core-ktx:1.16.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
 
 //    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.6.1"
-    implementation 'androidx.palette:palette:1.0.0'
+    implementation 'androidx.palette:palette-ktx:1.0.0'
 
     //navigation component
     implementation ("androidx.navigation:navigation-fragment-ktx:$nav_version")
@@ -87,17 +89,17 @@ dependencies {
     androidTestImplementation "com.google.truth:truth:1.1.4"
     testImplementation "androidx.arch.core:core-testing:2.2.0"
     androidTestImplementation "androidx.arch.core:core-testing:2.2.0"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     androidTestImplementation 'com.google.dagger:hilt-android-testing:2.44'
     kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.28-alpha'
-    debugImplementation "androidx.fragment:fragment-testing:1.6.2"
+    debugImplementation "androidx.fragment:fragment-testing:1.8.7"
 
     //Dagger - Hilt
-    implementation 'com.google.dagger:hilt-android:2.44.2'
-    kapt 'com.google.dagger:hilt-android-compiler:2.44.2'
-    implementation "androidx.activity:activity-ktx:1.4.0"
-    kapt 'androidx.hilt:hilt-compiler:1.0.0'
+    implementation "com.google.dagger:hilt-android:2.56.2"
+    ksp "com.google.dagger:hilt-compiler:2.56.2"
+    implementation "androidx.activity:activity-ktx:1.10.1"
+//    kapt 'androidx.hilt:hilt-compiler:1.0.0'
 
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
 
@@ -108,17 +110,17 @@ dependencies {
 
     //for supporting older APIs like(LocalDateTime, OffsetDateTime, DateTimeFormatter)
     //look at DateTimeUtility class
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.2")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
     // Firebase libraries
-    implementation(platform("com.google.firebase:firebase-bom:32.2.3"))
+    implementation(platform("com.google.firebase:firebase-bom:33.14.0"))
 
     // Firebase Authentication library
     implementation("com.google.firebase:firebase-auth-ktx")
     // Cloud Firestore library
     implementation("com.google.firebase:firebase-firestore-ktx")
     // firebase analytics
-    implementation 'com.google.firebase:firebase-analytics:17.4.1'
+    implementation 'com.google.firebase:firebase-analytics:22.4.0'
 
-    implementation("androidx.compose.material3:material3-window-size-class:1.1.1")
+    implementation("androidx.compose.material3:material3-window-size-class:1.3.2")
 }

--- a/app/src/main/java/com/dev/goalpulse/views/fragments/bottomNav/NewsFragment.kt
+++ b/app/src/main/java/com/dev/goalpulse/views/fragments/bottomNav/NewsFragment.kt
@@ -84,7 +84,7 @@ class NewsFragment : Fragment(R.layout.fragment_news) {
         searchView.editText.setOnEditorActionListener { _, _, _ ->
             if(searchView.text.toString() == "") newsViewModel.q = newsViewModel._q
             else {
-                searchBar.text = searchView.text
+                searchBar.setText(searchView.text)
                 newsViewModel.q = searchBar.text.toString()
             }
             searchView.hide()
@@ -164,7 +164,7 @@ class NewsFragment : Fragment(R.layout.fragment_news) {
     private fun implementApplyButton() {
         val apply = fullScreenBottomSheetView.findViewById<Button>(R.id.apply)
         apply.setOnClickListener {
-            if(searchBar.text == null || searchBar.text == "") newsViewModel.q = "football"
+            if(searchBar.text == "") newsViewModel.q = "football"
             else newsViewModel.q = searchBar.text.toString()
             lifecycleScope.launch(Dispatchers.IO) { newsViewModel.getEveryThingNews() }
             bottomSheet.dismiss()

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,10 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.1.1' apply false
-    id 'com.android.library' version '8.1.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
-    id 'com.google.dagger.hilt.android' version '2.44' apply false
+    id 'com.android.application' version '8.10.0' apply false
+    id 'com.android.library' version '8.10.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.1.21' apply false
+    id 'com.google.dagger.hilt.android' version '2.56.2' apply false
     id 'com.google.gms.google-services' version '4.3.15' apply false
+    id 'com.google.devtools.ksp' version '2.1.20-2.0.0' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Wed May 21 18:52:25 GST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The following dependencies were updated:
- Gradle wrapper from 8.0 to 8.11.1
- Android Gradle Plugin from 8.1.1 to 8.10.0
- Kotlin Gradle Plugin from 1.7.10 to 2.1.21
- Hilt from 2.44 to 2.56.2
- KSP from not present to 2.1.20-2.0.0
- Various AndroidX and Google Play services libraries.

Additionally:
- `compileSdk` updated from 34 to 35.
- `versionCode` incremented from 5 to 6.
- `versionName` changed from "1.0" to "1.0.1".
- Switched from `kotlin-kapt` to `ksp` for Hilt.
- `NewsFragment.kt`: Updated `searchBar.text` assignment to use `setText()` for clarity and to handle potential nullability issues.
- `.idea/deploymentTargetSelector.xml`: Updated the default emulator.