### PR TITLE
fix: Randomly connection timeout in Football API's requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/deploymentTargetSelector.xml
 .DS_Store
 /build
 /captures

--- a/app/src/main/java/com/dev/goalpulse/dependencyInjection/SingletonModule.kt
+++ b/app/src/main/java/com/dev/goalpulse/dependencyInjection/SingletonModule.kt
@@ -36,6 +36,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -109,6 +110,9 @@ object SingletonModule {
     @Provides
     fun provideFootballAPI(): FootballApi {
         val httpClient = OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
         httpClient.addInterceptor(object: Interceptor {
             override fun intercept(chain: Interceptor.Chain): Response {
                 val request = chain.request().newBuilder().addHeader(


### PR DESCRIPTION
fix: Added connection, read, and write timeouts to OkHttpClient

This change ensures that network requests to the Football API will timeout after 30 seconds, preventing indefinite hangs in case of network issues.

- Modified `SingletonModule.kt` to include `connectTimeout`, `readTimeout`, and `writeTimeout` for the OkHttpClient instance used by the Football API.
- Added `/.idea/deploymentTargetSelector.xml` to `.gitignore`.

Closes #12 