### PR TITLE
fix(DynamicLeagueFragment.kt):

### DIFF
--- a/app/src/main/java/com/dev/goalpulse/views/fragments/DynamicLeagueFragment.kt
+++ b/app/src/main/java/com/dev/goalpulse/views/fragments/DynamicLeagueFragment.kt
@@ -48,7 +48,8 @@ class DynamicLeagueFragment: Fragment(R.layout.fragment_dynamic_league),
     private lateinit var circularProgressIndicator: CircularProgressIndicator
     private lateinit var leagueMatchesRecyclerViewAdapter: LeagueMatchesRecyclerViewAdapter
 
-    var leagueOrder = 0 //league order in the tab view
+    //represents the tab index starting from 0 until the last item index in Shared.LEAGUES_IDS
+    var leagueOrder = 0
     private var offset = 0
     private var season = ""
     private var lastResponseMessage: String? = null
@@ -247,11 +248,11 @@ class DynamicLeagueFragment: Fragment(R.layout.fragment_dynamic_league),
                         }
                         else {
                             lifecycleScope.launch (Dispatchers.IO){
-                                this@DynamicLeagueFragment.offset += 50
+                                offset += 50
                                 footBallViewModel.getLeagueMatches(
                                     leagueId = Shared.LEAGUES_IDS[leagueOrder],
-                                    seasonId = this@DynamicLeagueFragment.season,  //seasonId = "eq.45769",
-                                    offset = this@DynamicLeagueFragment.offset.toString()
+                                    seasonId = season,  //seasonId = "eq.45769",
+                                    offset = offset.toString()
                                 )
                             }
                         }

--- a/app/src/main/java/com/dev/goalpulse/views/fragments/bottomNav/FootBallFragment.kt
+++ b/app/src/main/java/com/dev/goalpulse/views/fragments/bottomNav/FootBallFragment.kt
@@ -62,6 +62,7 @@ class FootBallFragment : Fragment(R.layout.fragment_football) {
         setOnClickListeners()
         viewPager.apply {
             adapter = FootBallViewPagerAdapter(childFragmentManager, lifecycle)
+            isUserInputEnabled = false
             registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
                 override fun onPageSelected(position: Int) {
                     tabLayout.selectTab(tabLayout.getTabAt(position))


### PR DESCRIPTION
- Use `offset` instead of `this@DynamicLeagueFragment.offset` for brevity.
- Use `season` instead of `this@DynamicLeagueFragment.season` for brevity.
- Updated comments for clarity.

minor refactor(FootBallFragment.kt):
- Disabled user input for the ViewPager to prevent swipe gestures from changing tabs.