### PR TITLE
feat: Handle internal server error (500) from API

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/dev/goalpulse/ResponseState.kt
+++ b/app/src/main/java/com/dev/goalpulse/ResponseState.kt
@@ -21,9 +21,9 @@ object ApiResponseHandler {
         return try {
             val response = call()
             Log.i("originalResponse", response.body().toString())
-            if (response.isSuccessful) {
-                ResponseState.Success(response.body())
-            } else {
+            if (response.isSuccessful) ResponseState.Success(response.body())
+            else if(response.code() == 500) ResponseState.Error(response.code().toString())
+            else {
                 // Get the raw error response as string first
                 val errorBodyString = response.errorBody()?.string() ?: ""
                 Log.d("API_ERROR", "Raw error response: $errorBodyString")

--- a/app/src/main/java/com/dev/goalpulse/views/fragments/DynamicLeagueFragment.kt
+++ b/app/src/main/java/com/dev/goalpulse/views/fragments/DynamicLeagueFragment.kt
@@ -202,7 +202,8 @@ class DynamicLeagueFragment: Fragment(R.layout.fragment_dynamic_league),
 
     private fun showErrorUI(errorMessage: String) {
         _errorLayoutBinding!!.apply {
-            errorText.text = errorMessage
+            if(errorMessage == "500") errorText.text = context?.getString(R.string.internal_server_error)
+            else errorText.text = errorMessage
             retryButton.setOnClickListener {
                 if(Shared.isConnected)
                     lifecycleScope.launch(Dispatchers.IO) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -74,4 +74,5 @@
     <string name="share">مشاركة</string>
     <string name="Expand_more">توسيع</string>
     <string name="match_pressure_timeline">الجدول الزمني للضغط</string>
+    <string name="internal_server_error">خطأ في الخادم الداخلي</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="no_results">No results</string>
     <string name="unknown_error">Unknown error accured</string>
     <string name="limit_reached">You have reached the request limit for the day, Go to https://dashboard.api-football.com to upgrade your plan.</string>
+    <string name="internal_server_error">Internal server error</string>">
 
     <string name="live_matches" translatable="false">all</string>
     <string name="retry">Retry</string>


### PR DESCRIPTION
This commit introduces specific handling for 500 internal server errors returned by the API.

**Modified files:**
- `ResponseState.kt`: Added logic to identify 500 errors and return a specific `ResponseState.Error` for them.
- `DynamicLeagueFragment.kt`: Updated the error UI to display a user-friendly "Internal server error" message when a 500 error occurs.
- `strings.xml` & `values-ar/strings.xml`: Added the "internal_server_error" string resource for localization.

**Deleted file:**
- `.idea/misc.xml`: Removed this IDE configuration file.