### PR TITLE
build: Increment versionCode to 7

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.dev.goalpulse"
         minSdk 27
         targetSdk 34
-        versionCode 6
-        versionName "1.0.1"
+        versionCode 7
+        versionName "1.0.1"        //major changes.features(added/removed).bug fixes
 
         testInstrumentationRunner "com.dev.goalpulse.HiltTestRunner"
 


### PR DESCRIPTION
The `versionCode` in `app/build.gradle` has been updated from 6 to 7. The `versionName` remains "1.0.1".